### PR TITLE
fix: correct dashboard link on room listings

### DIFF
--- a/add_room.html
+++ b/add_room.html
@@ -11,7 +11,7 @@
   <header class="bg-blue-700 text-white py-4">
     <div class="max-w-7xl mx-auto px-4 flex justify-between items-center">
       <h1 class="text-xl font-bold">StayFind</h1>
-      <a href="dashboard_owner.html" class="text-white hover:underline">Back to Dashboard</a>
+      <a href="owner_dashboard.html" class="text-white hover:underline">Back to Dashboard</a>
     </div>
   </header>
 

--- a/bookings_owner.html
+++ b/bookings_owner.html
@@ -11,7 +11,7 @@
   <header class="bg-blue-700 text-white py-4">
     <div class="max-w-7xl mx-auto px-4 flex justify-between items-center">
       <h1 class="text-xl font-bold">StayFind</h1>
-      <a href="dashboard_owner.html" class="text-white hover:underline">Back to Dashboard</a>
+      <a href="owner_dashboard.html" class="text-white hover:underline">Back to Dashboard</a>
     </div>
   </header>
 

--- a/my_rooms.html
+++ b/my_rooms.html
@@ -9,7 +9,7 @@
   <header class="bg-blue-700 text-white py-4">
     <div class="max-w-7xl mx-auto px-4 flex justify-between items-center">
       <h1 class="text-xl font-bold">StayFind</h1>
-      <a href="dashboard_owner.html" class="hover:underline">Back to Dashboard</a>
+      <a href="owner_dashboard.html" class="hover:underline">Back to Dashboard</a>
     </div>
   </header>
 

--- a/room_listings.html
+++ b/room_listings.html
@@ -11,7 +11,7 @@
   <header class="bg-blue-700 text-white py-4">
     <div class="max-w-7xl mx-auto px-4 flex justify-between items-center">
       <h1 class="text-xl font-bold">StayFind</h1>
-      <a href="dashboard_guest.html" class="text-white hover:underline">Back to Dashboard</a>
+      <a href="dashboard.html" class="text-white hover:underline">Back to Dashboard</a>
     </div>
   </header>
 

--- a/view_rooms.html
+++ b/view_rooms.html
@@ -11,7 +11,7 @@
   <header class="bg-blue-700 text-white py-4">
     <div class="max-w-7xl mx-auto px-4 flex justify-between items-center">
       <h1 class="text-xl font-bold">StayFind</h1>
-      <a href="dashboard_owner.html" class="text-white hover:underline">Back to Dashboard</a>
+      <a href="owner_dashboard.html" class="text-white hover:underline">Back to Dashboard</a>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- fix link on room listings page to point to the main dashboard

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -s http://localhost:8000/room_listings.html | rg 'Back to Dashboard'`
- `curl -s http://localhost:8000/dashboard.html | head`

------
https://chatgpt.com/codex/tasks/task_e_68b9e4036f808330bad48d7a69e89d09