### PR TITLE
Make booking and payment seed inserts idempotent

### DIFF
--- a/migrations/2025_09_create_bookings_and_payments.sql
+++ b/migrations/2025_09_create_bookings_and_payments.sql
@@ -1,0 +1,29 @@
+-- Creates bookings and payments tables and seeds initial data.
+-- Seed inserts are idempotent via INSERT IGNORE or ON DUPLICATE KEY UPDATE.
+
+CREATE TABLE IF NOT EXISTS bookings (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    room_id INT NOT NULL,
+    status VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS payments (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    booking_id INT NOT NULL,
+    amount DECIMAL(10,2) NOT NULL,
+    paid_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_payments_booking FOREIGN KEY (booking_id) REFERENCES bookings(id)
+);
+
+-- Insert a sample booking if it does not already exist.
+-- INSERT IGNORE ensures rerunning the migration will not insert duplicates or error.
+INSERT IGNORE INTO bookings (id, user_id, room_id, status)
+VALUES (1, 1, 101, 'confirmed');
+
+-- Insert a matching payment while keeping amount up to date.
+-- ON DUPLICATE KEY UPDATE makes this insert idempotent.
+INSERT INTO payments (id, booking_id, amount)
+VALUES (1, 1, 100.00)
+ON DUPLICATE KEY UPDATE amount = VALUES(amount);


### PR DESCRIPTION
## Summary
- create bookings and payments migration
- use INSERT IGNORE / ON DUPLICATE KEY UPDATE so seeding is idempotent

## Testing
- `cat migrations/2025_09_create_bookings_and_payments.sql | sed -e '1i PRAGMA foreign_keys=ON;' -e 's/INT AUTO_INCREMENT PRIMARY KEY/INTEGER PRIMARY KEY AUTOINCREMENT/' -e 's/INT NOT NULL/INTEGER NOT NULL/g' -e 's/DECIMAL(10,2)/REAL/' -e 's/TIMESTAMP DEFAULT CURRENT_TIMESTAMP/TEXT DEFAULT CURRENT_TIMESTAMP/' -e 's/INSERT IGNORE/INSERT OR IGNORE/' -e 's/ON DUPLICATE KEY UPDATE amount = VALUES(amount)/ON CONFLICT(id) DO UPDATE SET amount=excluded.amount/' | sqlite3 test.db`
- `cat migrations/2025_09_create_bookings_and_payments.sql | sed -e '1i PRAGMA foreign_keys=ON;' -e 's/INT AUTO_INCREMENT PRIMARY KEY/INTEGER PRIMARY KEY AUTOINCREMENT/' -e 's/INT NOT NULL/INTEGER NOT NULL/g' -e 's/DECIMAL(10,2)/REAL/' -e 's/TIMESTAMP DEFAULT CURRENT_TIMESTAMP/TEXT DEFAULT CURRENT_TIMESTAMP/' -e 's/INSERT IGNORE/INSERT OR IGNORE/' -e 's/ON DUPLICATE KEY UPDATE amount = VALUES(amount)/ON CONFLICT(id) DO UPDATE SET amount=excluded.amount/' | sqlite3 test.db`
- `sqlite3 test.db "SELECT count(*) FROM bookings; SELECT count(*) FROM payments;"`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9e4056514833086784270a57d8006